### PR TITLE
pad vocab size to multiple of 64

### DIFF
--- a/train.py
+++ b/train.py
@@ -134,7 +134,7 @@ if __name__ == "__main__":
     palm_config = PaLMConfig(n_embed=768,
                              n_head=6,
                              dropout=0.1,
-                             vocab_size=tokenizer.vocab_size,
+                             vocab_size=50304, # GPT-2 vocab_size of 50257, padded up to nearest multiple of 64 for efficiency
                              n_layer=4)
 
     model = PaLM(palm_config).to(device)


### PR DESCRIPTION
taken from nanoGPT: https://github.com/karpathy/nanoGPT/blob/a82b33b525ca9855d705656387698e13eb8e8d4b/model.py#LL118C4-L118C15

Discussion about vocab embeddings padding: https://twitter.com/karpathy/status/1621578354024677377?lang=en

Padding the vocab size to the nearest multiple of 64 increased the throughput on my 3090 from 1.19 it/s to 1.24 it/s. 